### PR TITLE
Docs and tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# Contributing to RheologyCalculator.jl
+
+Contributions are welcome — bug reports, feature requests, documentation
+improvements, new rheologies, and code.
+
+## Reporting issues and getting support
+
+- Please open an [issue](https://github.com/albert-de-montserrat/RheologyCalculator.jl/issues)
+  for bugs, questions, or feature requests.
+- When reporting a bug, include a minimal reproducible example, the error
+  message, and your Julia and package versions (`] status`).
+
+## Contributing code
+
+1. Fork the repository and create a feature branch.
+2. Install the development environment:
+   ```julia
+   using Pkg
+   Pkg.develop(path = ".")
+   Pkg.instantiate()
+   ```
+3. Make your change. New rheologies are added by subtyping `AbstractViscosity`,
+   `AbstractElasticity`, or `AbstractPlasticity`, specialising
+   `series_state_functions` / `parallel_state_functions`, and implementing the
+   corresponding state functions (see `rheologies/RheologyDefinitions.jl` for
+   canonical examples and `CLAUDE.md` for the architecture).
+4. Add or update tests under `test/` and run the suite:
+   ```julia
+   using Pkg
+   Pkg.test("RheologyCalculator")
+   ```
+5. Open a pull request describing the change. CI must pass before review.
+
+## Code style
+
+Follow the conventions of the surrounding code. The core relies on
+`@generated` functions and type dispatch to stay allocation-free — keep new
+core code type-stable and avoid runtime allocation in the solver hot path.
+
+## Code of conduct
+
+Please be respectful and constructive in all interactions. By participating you
+agree to uphold a welcoming and harassment-free environment.

--- a/JOSS_PAPER_PLAN.md
+++ b/JOSS_PAPER_PLAN.md
@@ -1,0 +1,143 @@
+# Plan: JOSS paper for RheologyCalculator.jl
+
+## Context
+
+`RheologyCalculator.jl` builds and solves local (point-wise) rheological
+constitutive models assembled from viscous, elastic, and plastic building
+blocks, composed in series / parallel / nested networks and solved with a
+Newton–Raphson scheme. It targets geodynamics / Stokes solvers that must solve
+the local rheological system at every quadrature point each time-step. It is
+MIT-licensed, has Documenter-based docs, a test suite (unit tests + Aqua), CI,
+and a large set of validated examples. This makes it a strong candidate for a
+**JOSS** (Journal of Open Source Software) submission.
+
+JOSS reviews the *software*; the paper is a short (~250–1000 word) advertisement
+plus a "Statement of Need". The bulk of the work is ensuring the repository meets
+JOSS submission requirements, then writing `paper.md` + `paper.bib`.
+
+**Decisions locked in with the user:**
+- **Authors:** Albert de Montserrat, Boris Kaus, Thibault Duretz (the three main
+  git contributors; ORCIDs/affiliations to be confirmed during execution).
+- **Scope:** produce a *full draft* of `paper.md` and `paper.bib`, not just a scaffold.
+
+## Deliverables
+
+1. This plan, stored in **two** locations (per the request):
+   - `/Users/albert/.claude/plans/make-a-plan-to-sparkling-kazoo.md` (auto-loaded here).
+   - `JOSS_PAPER_PLAN.md` in the repo root (for other agents). *Written on approval —
+     plan mode forbids editing repo files now.*
+2. `paper/paper.md` — JOSS paper with YAML front-matter + prose.
+3. `paper/paper.bib` — BibTeX references.
+4. (Optional) `paper/` figure(s) reusing existing `docs/assets/*.png`.
+5. A short pre-submission checklist confirming repo meets JOSS criteria.
+
+## JOSS submission requirements (verify during execution)
+
+- [x] Open source, OSI license — MIT `LICENSE` present. ✅
+- [x] Public VCS repo with substantial scholarly effort. ✅
+- [x] Documentation — Documenter site under `docs/`. ✅ (confirm it covers
+      install, API/usage, and a statement of functionality)
+- [x] Automated tests — `test/runtests.jl`, Aqua, per-model tests. ✅
+- [ ] **Community guidelines** — JOSS expects `CONTRIBUTING`/contribution +
+      issue-reporting + support guidance. Repo has none → add a short
+      `CONTRIBUTING.md` (or a README section) during execution.
+- [ ] Version tagged + archived (Zenodo DOI) — needed at submission time, not draft time.
+- [ ] Paper length 250–1000 words.
+
+## `paper.md` structure
+
+YAML front-matter:
+```yaml
+---
+title: 'RheologyCalculator.jl: Composable local rheological models for geodynamics'
+tags:
+  - Julia
+  - geodynamics
+  - rheology
+  - constitutive models
+  - viscoelastoplasticity
+authors:
+  - name: Albert de Montserrat
+    orcid: 0000-0000-0000-0000   # confirm
+    affiliation: 1
+  - name: Boris J. P. Kaus
+    affiliation: 2
+  - name: Thibault Duretz
+    affiliation: 3
+affiliations:
+  - name: ETH Zürich, Switzerland   # confirm
+    index: 1
+  - name: Johannes Gutenberg University Mainz, Germany
+    index: 2
+  - name: Goethe University Frankfurt, Germany   # confirm
+    index: 3
+date: <submission date>
+bibliography: paper.bib
+---
+```
+
+Prose sections:
+1. **Summary** — what the package does, in accessible terms: composable
+   viscous/elastic/plastic elements → series/parallel/nested networks →
+   nonlinear residual solved by Newton iteration; allocation-free via Julia
+   `@generated` / type dispatch; returns stress, strain-rate, pressure at a point.
+2. **Statement of Need** — geodynamic Stokes solvers evaluate rheology at every
+   quadrature point every time-step; hand-coding each viscoelastoplastic
+   combination (Maxwell, Kelvin–Voigt, Burgers, VEP, VEVP, Drucker–Prager, cap
+   plasticity, Cam-Clay, rate-and-state...) is error-prone and rigid. This
+   package generates the local nonlinear system automatically from composed
+   elements and solves it, decoupling the material catalogue from the solver.
+   Position relative to the Julia geodynamics ecosystem (GeoParams.jl,
+   JustRelax.jl, LaMEM/JustPIC) and to hand-written constitutive updates.
+3. **Design / functionality** (brief) — state-function interface, `SeriesModel`/
+   `ParallelModel`, `generate_equations`, `solve`, ForwardDiff Jacobian, elastic
+   strain-rate correction. Keep concise — JOSS is not a manual.
+4. **Example / validation** — one code snippet (Maxwell from README) + reference
+   to examples validated against analytical solutions
+   (`examples/Maxwell_KV_Maxwell.jl`, `docs/src/strain_rate_correction.md`).
+   Optionally embed one figure from `docs/assets/`.
+5. **Acknowledgements** — funding/ecosystem (confirm with user).
+6. **References** — via `paper.bib`.
+
+## `paper.bib` — references to gather
+
+- Julia language (Bezanson et al. 2017).
+- ForwardDiff.jl (Revels et al. 2016), StaticArrays.jl.
+- Ecosystem: GeoParams.jl, JustRelax.jl, LaMEM (Kaus et al.), JustPIC.jl.
+- Rheology/plasticity sources already cited in README: Popov et al. 2025
+  (VEP+Cap), Abbo & Sloan 1995 (Hyperbolic), Golchin et al. 2021, de Souza Neto
+  (Cam-Clay), Herrendörfer et al. 2018 (rate-and-state).
+- General geodynamics rheology background (e.g. Gerya textbook, Moresi/May
+  Stokes-solver refs) as needed for the Statement of Need.
+
+## Key repo files to reuse (no core code changes needed)
+
+- `README.md`, `docs/src/index.md` — source prose for Summary.
+- `CLAUDE.md` — authoritative architecture description for the Design section.
+- `examples/Maxwell_KV_Maxwell.jl`, `examples/Maxwell_VEP.jl`, etc. — validation.
+- `docs/assets/*.png` — ready-made figures.
+- `Project.toml` — deps for the software-paper acknowledgements/citations.
+
+## Execution steps (after approval)
+
+1. Write `JOSS_PAPER_PLAN.md` to repo root (copy of this plan for other agents).
+2. Create `paper/` directory; write full `paper.md` (front-matter + all sections,
+   within word limit) and `paper.bib`.
+3. Optionally copy/reference one figure into `paper/`.
+4. Add a minimal `CONTRIBUTING.md` (or README "Contributing" section) to satisfy
+   JOSS community-guidelines criterion.
+5. Leave ORCIDs, affiliations, funding, and submission date as clearly-marked
+   TODOs for the user to confirm.
+
+## Verification
+
+- Word count of `paper.md` body is 250–1000 (`wc -w` excluding front-matter/bib).
+- YAML front-matter parses (valid keys per JOSS schema; every `affiliation`
+  index has a matching `affiliations` entry).
+- Every in-text `[@key]` citation resolves to an entry in `paper.bib` (grep keys).
+- Optionally build the paper PDF locally with the JOSS/Open Journals
+  `inara`/`openjournals` Docker action to confirm it compiles, or rely on the
+  JOSS "Compile PDF" bot after opening the submission.
+- Repo still passes existing checks (no source changes, so `test/runtests.jl`
+  unaffected).
+```

--- a/JOSS_PAPER_PLAN.md
+++ b/JOSS_PAPER_PLAN.md
@@ -42,7 +42,7 @@ JOSS submission requirements, then writing `paper.md` + `paper.bib`.
       issue-reporting + support guidance. Repo has none → add a short
       `CONTRIBUTING.md` (or a README section) during execution.
 - [ ] Version tagged + archived (Zenodo DOI) — needed at submission time, not draft time.
-- [ ] Paper length 250–1000 words.
+- [ ] Paper length: target **around 1000 words** (JOSS accepts 250–1000; aim for ~950–1000 to use the full budget).
 
 ## `paper.md` structure
 
@@ -131,7 +131,7 @@ Prose sections:
 
 ## Verification
 
-- Word count of `paper.md` body is 250–1000 (`wc -w` excluding front-matter/bib).
+- Word count of `paper.md` body is **around 1000** (target ~950–1000, JOSS hard cap 1000; `wc -w` excluding front-matter/bib).
 - YAML front-matter parses (valid keys per JOSS schema; every `affiliation`
   index has a matching `affiliations` entry).
 - Every in-text `[@key]` citation resolves to an entry in `paper.bib` (grep keys).

--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ authors = ["albert-de-montserrat <albert.de.montserrat@gmail.com>"]
 
 [deps]
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
-JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
@@ -14,7 +13,7 @@ TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 [compat]
 Aqua = "0.8.13"
 ForwardDiff = "1.4.1"
-JET = "0.11.5"
+JET = "0.9, 0.10, 0.11"
 LaTeXStrings = "1.4.0"
 LinearAlgebra = "1.10"
 StaticArrays = "1.9"

--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,11 @@
 name = "RheologyCalculator"
 uuid = "62cdc9a2-0e94-40de-8fb5-c079398d65d0"
-authors = ["albert-de-montserrat <albert.de.montserrat@gmail.com>"]
 version = "0.1.1"
+authors = ["albert-de-montserrat <albert.de.montserrat@gmail.com>"]
 
 [deps]
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
@@ -13,6 +14,7 @@ TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 [compat]
 Aqua = "0.8.13"
 ForwardDiff = "1.4.1"
+JET = "0.11.5"
 LaTeXStrings = "1.4.0"
 LinearAlgebra = "1.10"
 StaticArrays = "1.9"
@@ -22,8 +24,9 @@ julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "Statistics", "Test"]
+test = ["Aqua", "Statistics", "Test", "JET"]

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![CI](https://github.com/albert-de-montserrat/RheologyCalculator.jl/actions/workflows/ci.yml/badge.svg)](https://github.com/albert-de-montserrat/RheologyCalculator.jl/actions/workflows/ci.yml)
 [![Docs](https://img.shields.io/badge/docs-dev-blue.svg)](https://albert-de-montserrat.github.io/RheologyCalculator.jl/dev/)
+[![codecov](https://codecov.io/gh/albert-de-montserrat/RheologyCalculator.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/albert-de-montserrat/RheologyCalculator.jl)
+[![version](https://juliahub.com/docs/General/RheologyCalculator/stable/version.svg)](https://juliahub.com/ui/Packages/General/RheologyCalculator)
 
 `RheologyCalculator.jl` builds and solves local rheological models from small
 viscous, elastic, and plastic building blocks. Elements can be composed in
@@ -12,6 +14,35 @@ The package core is independent of any particular material catalogue. The
 example rheologies in [`rheologies/`](./rheologies) define common viscous,
 elastic, plastic, and pressure-dependent laws by extending the state-function
 interface.
+
+## Installation
+
+`RheologyCalculator.jl` is registered in the Julia General registry:
+
+```julia
+using Pkg
+Pkg.add("RheologyCalculator")
+```
+
+## Rheological element definitions
+
+The package exports the composition and solver machinery (`SeriesModel`,
+`ParallelModel`, `solve`, `initial_guess_x`, …) but **not** the concrete
+constitutive elements used throughout the examples (`LinearViscosity`,
+`Elasticity`, `DruckerPrager`, and the rest). Those are defined in
+[`rheologies/RheologyDefinitions.jl`](./rheologies/RheologyDefinitions.jl),
+which extends the package's state-function interface, and must be loaded
+explicitly:
+
+```julia
+using RheologyCalculator
+include("rheologies/RheologyDefinitions.jl")
+```
+
+The `include` path is relative to the current working directory, so the examples
+below assume a clone of this repository. When the package is installed with
+`Pkg.add`, `include` the file by an absolute path, or copy it (with any
+companion files from `rheologies/` that it needs) into your own project.
 
 ## Quick Start
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -14,6 +14,35 @@ catalogue. The repository's `rheologies/` directory contains example concrete
 laws such as `LinearViscosity`, `Elasticity`, and `DruckerPrager`; project code
 can define its own types by extending the same state-function interface.
 
+## Installation
+
+`RheologyCalculator.jl` is registered in the Julia General registry:
+
+```julia
+using Pkg
+Pkg.add("RheologyCalculator")
+```
+
+## Loading rheological elements
+
+The package exports the composition and solver machinery ([`SeriesModel`](@ref),
+[`ParallelModel`](@ref), [`solve`](@ref), [`initial_guess_x`](@ref), …) but not
+the concrete constitutive elements used in the examples (`LinearViscosity`,
+`Elasticity`, `DruckerPrager`, and the rest). Those are defined in
+`rheologies/RheologyDefinitions.jl` in the repository, which extends the
+state-function interface documented in [Rheologies](@ref), and must be loaded
+explicitly:
+
+```julia
+using RheologyCalculator
+include("rheologies/RheologyDefinitions.jl")
+```
+
+The `include` path is relative to the current working directory, so the examples
+here assume a clone of the repository. When the package is installed with
+`Pkg.add`, `include` the file by an absolute path, or copy it into your own
+project.
+
 The typical workflow is:
 
 1. Define rheological elements, such as viscosity, elasticity, or plasticity.

--- a/docs/src/stress.md
+++ b/docs/src/stress.md
@@ -1,5 +1,15 @@
 # Stress-time curve of a Burger's material
 
+The post-processing helpers [`compute_stress_elastic`](@ref RheologyCalculator.compute_stress_elastic)
+and [`compute_pressure_elastic`](@ref RheologyCalculator.compute_pressure_elastic)
+are not exported, so import them alongside the element definitions:
+
+```julia
+using RheologyCalculator
+import RheologyCalculator: compute_stress_elastic, compute_pressure_elastic
+include("rheologies/RheologyDefinitions.jl")
+```
+
 We start by defining the material properties 
 ```julia
 η1, η2, η3 = 5e19, 1e20, 1e21

--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -1,0 +1,91 @@
+@article{Bezanson2017,
+  author  = {Bezanson, Jeff and Edelman, Alan and Karpinski, Stefan and Shah, Viral B.},
+  title   = {Julia: A Fresh Approach to Numerical Computing},
+  journal = {SIAM Review},
+  volume  = {59},
+  number  = {1},
+  pages   = {65--98},
+  year    = {2017},
+  doi     = {10.1137/141000671}
+}
+
+@article{Revels2016,
+  author  = {Revels, Jarrett and Lubin, Miles and Papamarkou, Theodore},
+  title   = {Forward-Mode Automatic Differentiation in Julia},
+  journal = {arXiv preprint arXiv:1607.07892},
+  year    = {2016},
+  doi     = {10.48550/arXiv.1607.07892}
+}
+
+@misc{StaticArrays,
+  author       = {Ferris, Andy and contributors},
+  title        = {{StaticArrays.jl}: Statically sized arrays for Julia},
+  howpublished = {\url{https://github.com/JuliaArrays/StaticArrays.jl}},
+  note         = {Accessed 2026},
+  year         = {2016}
+}
+
+@article{GeoParams,
+  author  = {Kaus, Boris J. P. and de Montserrat, Albert and others},
+  title   = {{GeoParams.jl}: Consistent geodynamic material parameters in Julia},
+  journal = {In preparation / software},
+  year    = {2024},
+  note    = {\url{https://github.com/JuliaGeodynamics/GeoParams.jl} -- TODO: update citation}
+}
+
+@misc{JustRelax,
+  author       = {de Montserrat, Albert and Riel, Nicolas and Kaus, Boris J. P. and others},
+  title        = {{JustRelax.jl}: Pseudo-transient accelerated Stokes solvers in Julia},
+  howpublished = {\url{https://github.com/PTsolvers/JustRelax.jl}},
+  year         = {2024},
+  note         = {TODO: update citation}
+}
+
+@article{Kaus2016,
+  author  = {Kaus, Boris J. P. and Popov, Anton A. and Baumann, Tobias S. and Push, Adina E. and Bauville, Arthur and Fernandez, Naiara and Collignon, Marine},
+  title   = {Forward and inverse modelling of lithospheric deformation on geological timescales},
+  journal = {Proceedings of NIC Symposium 2016},
+  year    = {2016},
+  note    = {LaMEM software. TODO: verify reference}
+}
+
+@article{Popov2025,
+  author  = {Popov, Anton A. and others},
+  title   = {Visco-elasto-plastic rheology with a cap for geodynamic modelling},
+  journal = {TODO: journal},
+  year    = {2025},
+  note    = {TODO: complete reference (VEP + Cap model cited in README)}
+}
+
+@article{Abbo1995,
+  author  = {Abbo, A. J. and Sloan, S. W.},
+  title   = {A smooth hyperbolic approximation to the Mohr-Coulomb yield criterion},
+  journal = {Computers \& Structures},
+  volume  = {54},
+  number  = {3},
+  pages   = {427--441},
+  year    = {1995},
+  doi     = {10.1016/0045-7949(94)00339-5}
+}
+
+@article{Golchin2021,
+  author  = {Golchin, Ali and Vardon, Philip J. and Hicks, Michael A.},
+  title   = {A thermodynamically based constitutive model for clays},
+  journal = {Computers and Geotechnics},
+  volume  = {135},
+  pages   = {104097},
+  year    = {2021},
+  doi     = {10.1016/j.compgeo.2021.104097},
+  note    = {TODO: verify reference for the Golchin Cam-Clay variant}
+}
+
+@article{Herrendorfer2018,
+  author  = {Herrendörfer, Robert and van Dinther, Ylona and Gerya, Taras and Dalguer, Luis A.},
+  title   = {Earthquake supercycle in subduction zones controlled by the width of the seismogenic zone},
+  journal = {Nature Geoscience},
+  volume  = {8},
+  pages   = {471--474},
+  year    = {2015},
+  doi     = {10.1038/ngeo2427},
+  note    = {TODO: confirm this is the intended rate-and-state reference (Herrendörfer et al., 2018)}
+}

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -1,0 +1,126 @@
+---
+title: 'RheologyCalculator.jl: Composable local rheological models for geodynamics'
+tags:
+  - Julia
+  - geodynamics
+  - rheology
+  - constitutive models
+  - viscoelastoplasticity
+  - automatic differentiation
+authors:
+  - name: Albert de Montserrat
+    orcid: 0000-0000-0000-0000 # TODO: confirm ORCID
+    affiliation: 1
+  - name: Boris J. P. Kaus
+    orcid: 0000-0000-0000-0000 # TODO: confirm ORCID
+    affiliation: 2
+  - name: Thibault Duretz
+    orcid: 0000-0000-0000-0000 # TODO: confirm ORCID
+    affiliation: 3
+affiliations:
+  - name: Institute of Geophysics, ETH Zürich, Switzerland # TODO: confirm affiliation
+    index: 1
+  - name: Institute of Geosciences, Johannes Gutenberg University Mainz, Germany # TODO: confirm affiliation
+    index: 2
+  - name: Institut für Geowissenschaften, Goethe University Frankfurt, Germany # TODO: confirm affiliation
+    index: 3
+date: 1 January 2026 # TODO: set submission date
+bibliography: paper.bib
+---
+
+# Summary
+
+The mechanical behaviour of rocks over geological time is described by
+constitutive laws that combine viscous, elastic, and plastic deformation. In
+numerical geodynamics these laws are evaluated locally — at every integration
+point of a mesh and at every time-step — to relate stress, strain-rate, and
+pressure. `RheologyCalculator.jl` is a Julia [@Bezanson2017] package that builds
+and solves such *local* rheological models from small, reusable building blocks.
+Individual viscous, elastic, and plastic elements are composed in series
+(strain-rates add, Maxwell-like), in parallel (stresses add, Kelvin–Voigt-like),
+or in arbitrarily nested hybrid networks. From a composed model the package
+automatically generates the corresponding nonlinear residual system and solves
+it with a Newton–Raphson scheme, returning the updated deviatoric stress,
+strain-rate, and pressure at a point.
+
+The design is type-dispatch driven and uses Julia's `@generated` functions
+throughout, so that equation assembly and tuple traversals are resolved at
+compile time and the resulting solver is allocation-free and type-stable. The
+Jacobian required by the Newton solver is obtained by automatic differentiation
+with `ForwardDiff.jl` [@Revels2016], and small fixed-size state vectors are
+represented with `StaticArrays.jl` [@StaticArrays], making the solver suitable
+for the hot inner loop of a Stokes solver. The computational core is
+deliberately independent of any particular material catalogue: concrete laws
+(e.g. linear and power-law viscosity, diffusion and dislocation creep,
+compressible and incompressible elasticity, Drucker–Prager and cap plasticity,
+modified Cam-Clay, and rate-and-state friction) are supplied as example
+definitions that extend a small state-function interface, and users can add
+their own laws the same way.
+
+# Statement of need
+
+Geodynamic Stokes solvers must evaluate the local rheology at every quadrature
+point on every time-step, often for strongly nonlinear
+visco-elasto-visco-plastic combinations. Traditionally, each combination —
+Maxwell, Kelvin–Voigt, Burgers, visco-elasto-plastic (VEP), VEVP,
+pressure-dependent yielding, dilatant plasticity — is hand-derived and
+hand-coded as a bespoke local stress update. This is tedious and error-prone,
+couples the material model tightly to the solver, and makes it difficult to
+experiment with new element combinations or to guarantee consistent, converged
+local solutions.
+
+`RheologyCalculator.jl` addresses this by treating the local constitutive update
+as a graph of composable elements. Given a composite model, it generates the
+system of equations automatically, differentiates it exactly via forward-mode
+automatic differentiation, and solves it to a prescribed tolerance. This
+decouples the *material catalogue* from the *solver machinery*: a new rheology is
+added by specialising two dispatch methods and implementing its state functions,
+after which it can be freely combined with any existing element in series or
+parallel. The package complements the Julia geodynamics ecosystem — such as
+`GeoParams.jl` for material parameters [@GeoParams], and the `JustRelax.jl`
+[@JustRelax] and `LaMEM` [@Kaus2016] solvers — by providing a general, reusable
+engine for the point-wise nonlinear rheological problem that these solvers
+repeatedly need to solve.
+
+# Functionality
+
+A model is assembled from elements with `SeriesModel` and `ParallelModel`, which
+may be nested:
+
+```julia
+using RheologyCalculator
+include("rheologies/RheologyDefinitions.jl")
+
+# Maxwell viscoelastic element (viscous + elastic in series)
+c = SeriesModel(LinearViscosity(1e22), IncompressibleElasticity(1e10))
+
+vars   = (; ε = 1.0e-14, θ = 0.0)          # prescribed kinematic inputs
+args   = (; τ = 1.0e3, P = 0.0)            # initial guess for unknowns
+others = (; dt = 1.0e10, τ0 = (0.0,), P0 = (0.0,))  # history / auxiliary fields
+
+x = initial_guess_x(c, vars, args, others)
+x = solve(c, x, vars, others)              # Newton solve
+```
+
+More elaborate networks — generalized Maxwell/Kelvin–Voigt bodies, Burgers
+models, and elastic elements embedded inside parallel branches — are built by
+nesting the same two constructors. The solver applies an elastic strain-rate
+correction to account for stress history before iterating, and post-processing
+utilities recover the updated elastic stress and pressure from the converged
+solution vector.
+
+The package is documented with `Documenter.jl` and ships an extensive set of
+runnable examples, several of which are validated against analytical solutions
+(for example, the mixed Kelvin–Voigt/Maxwell response) and against published
+plasticity models, including VEP with a cap [@Popov2025], the hyperbolic yield
+surface of @Abbo1995, the modified Cam-Clay formulation of @Golchin2021, and
+rate-and-state friction [@Herrendorfer2018]. Correctness is checked by a test
+suite covering the equation graphs, Jacobians, and individual rheologies,
+together with `Aqua.jl` quality assurance tests.
+
+# Acknowledgements
+
+We acknowledge contributions from the Julia geodynamics community. <!-- TODO:
+add funding sources and grant numbers. -->
+
+# References

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -49,13 +49,16 @@ compile time and the resulting solver is allocation-free and type-stable. The
 Jacobian required by the Newton solver is obtained by automatic differentiation
 with `ForwardDiff.jl` [@Revels2016], and small fixed-size state vectors are
 represented with `StaticArrays.jl` [@StaticArrays], making the solver suitable
-for the hot inner loop of a Stokes solver. The computational core is
-deliberately independent of any particular material catalogue: concrete laws
-(e.g. linear and power-law viscosity, diffusion and dislocation creep,
-compressible and incompressible elasticity, Drucker–Prager and cap plasticity,
-modified Cam-Clay, and rate-and-state friction) are supplied as example
-definitions that extend a small state-function interface, and users can add
-their own laws the same way.
+for the hot inner loop of a Stokes solver. Both the deviatoric
+(stress/strain-rate) and volumetric (pressure/volumetric strain-rate) parts of
+the response are handled, and history-dependent quantities such as the elastic
+stress and pressure from the previous time-step are carried through the solve.
+The computational core is deliberately independent of any particular material
+catalogue: concrete laws (e.g. linear and power-law viscosity, diffusion and
+dislocation creep, compressible and incompressible elasticity, Drucker–Prager
+and cap plasticity, modified Cam-Clay, and rate-and-state friction) are supplied
+as example definitions that extend a small state-function interface, and users
+can add their own laws the same way.
 
 # Statement of need
 
@@ -76,7 +79,18 @@ automatic differentiation, and solves it to a prescribed tolerance. This
 decouples the *material catalogue* from the *solver machinery*: a new rheology is
 added by specialising two dispatch methods and implementing its state functions,
 after which it can be freely combined with any existing element in series or
-parallel. The package complements the Julia geodynamics ecosystem — such as
+parallel, and the number and identity of the unknowns are derived automatically
+from the composed model rather than fixed in advance.
+
+Because the residual and its Jacobian are generated and differentiated
+programmatically, the local solve is both consistent — the same equations are
+used to evaluate the residual and to build the tangent operator — and robust,
+which matters for the strongly nonlinear yielding and creep laws common in
+lithospheric-scale simulations. The same abstraction also lowers the barrier to
+methodological experimentation: comparing, for instance, a regularised versus an
+unregularised plastic element, or a Burgers against a generalized Maxwell body,
+requires only re-composing existing building blocks. The package complements the
+Julia geodynamics ecosystem — such as
 `GeoParams.jl` for material parameters [@GeoParams], and the `JustRelax.jl`
 [@JustRelax] and `LaMEM` [@Kaus2016] solvers — by providing a general, reusable
 engine for the point-wise nonlinear rheological problem that these solvers
@@ -104,8 +118,19 @@ x = solve(c, x, vars, others)              # Newton solve
 
 More elaborate networks — generalized Maxwell/Kelvin–Voigt bodies, Burgers
 models, and elastic elements embedded inside parallel branches — are built by
-nesting the same two constructors. The solver applies an elastic strain-rate
-correction to account for stress history before iterating, and post-processing
+nesting the same two constructors. Internally, `SeriesModel` and `ParallelModel`
+separate their arguments into direct elements and nested branches at construction
+time, and a compile-time routine traverses this tree to produce one residual
+equation per unknown. Each element declares which state functions it contributes
+through the `series_state_functions` and `parallel_state_functions` interface,
+and the equations are tagged as global (the top-level kinematic constraints) or
+local (element-level relations) so that the residual can be assembled with the
+correct coupling between parent and child equations. Prescribed kinematic inputs
+are passed differentiably, whereas non-differentiated auxiliary and history
+fields — time-step size, previous elastic stress and pressure, grain size,
+temperature — are routed to the elements that need them without entering the
+automatic-differentiation path. Before iterating, the solver applies an elastic
+strain-rate correction to account for stress history, and post-processing
 utilities recover the updated elastic stress and pressure from the converged
 solution vector.
 

--- a/test/test_equation_graphs.jl
+++ b/test/test_equation_graphs.jl
@@ -11,6 +11,18 @@ function equation_graph(c)
     end
 end
 
+@testset "parallel linear viscosity acts as lower cutoff" begin
+    ε = 1.0e-14
+    η_soft = 1.0e12
+    η_floor = 1.0e16
+    c = SeriesModel(ParallelModel(SeriesModel(LinearViscosity(η_soft)), LinearViscosity(η_floor)))
+    vars = (; ε)
+    x = initial_guess_x(c, vars, (; τ = 1.0), NamedTuple())
+    x = solve(c, x, vars, NamedTuple())
+
+    @test x[1] / (2 * ε) ≈ η_soft + η_floor
+end
+
 @testset "equation graphs for composite layouts" begin
     v1 = LinearViscosity(1.0)
     v2 = LinearViscosity(2.0)

--- a/test/test_type_stability.jl
+++ b/test/test_type_stability.jl
@@ -1,0 +1,37 @@
+using JET
+import RheologyCalculator: compute_pressure_elastic, compute_residual, compute_stress_elastic
+
+function type_stability_fixture()
+    viscous = LinearViscosity(5.0e19)
+    elastic = Elasticity(1.0e10, 1.0e12)
+    c = SeriesModel(elastic, viscous)
+
+    vars = (; ε = 1.0e-15, θ = 1.0e-20)
+    args = (; τ = 1.0e2, P = 1.0e6)
+    others = (; dt = 1.0e10, τ0 = (0.0,), P0 = (0.0,))
+    x = initial_guess_x(c, vars, args, others)
+    xnorm = normalisation_x(c, 1.0e6, 1.0e-15)
+
+    return c, vars, others, x, xnorm
+end
+
+@testset "Type stability" begin
+    c, vars, others, x, xnorm = type_stability_fixture()
+
+    eqs = @inferred generate_equations(c)
+    @test length(eqs) == length(x)
+
+    @inferred initial_guess_x(c, vars, (; τ = 1.0e2, P = 1.0e6), others)
+    @inferred normalisation_x(c, 1.0e6, 1.0e-15)
+    @inferred compute_residual(c, x, vars, others)
+    @inferred compute_stress_elastic(c, x, others)
+    @inferred compute_pressure_elastic(c, x, others)
+    @inferred solve(c, x, vars, others; xnorm0 = xnorm, itermax = 1, verbose = false)
+
+    JET.@test_opt generate_equations(c)
+    JET.@test_opt initial_guess_x(c, vars, (; τ = 1.0e2, P = 1.0e6), others)
+    JET.@test_opt normalisation_x(c, 1.0e6, 1.0e-15)
+    JET.@test_opt compute_residual(c, x, vars, others)
+    JET.@test_opt compute_stress_elastic(c, x, others)
+    JET.@test_opt compute_pressure_elastic(c, x, others)
+end


### PR DESCRIPTION
## Summary

- **README**: add an Installation section for the registered package and a section explaining that concrete rheology elements live in `rheologies/RheologyDefinitions.jl` and must be `include`d explicitly; add codecov and JuliaHub version badges
- **Docs**: expand `docs/src/index.md` and add `docs/src/stress.md`
- **Tests**: add `test/test_equation_graphs.jl` and `test/test_type_stability.jl`
- **CONTRIBUTING.md**: community guidelines to satisfy JOSS criteria

## Test plan

- CI runs the test suite (including the new equation-graph and type-stability tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)