### PR TITLE
fix bug branch

### DIFF
--- a/src/equation_system/equations.jl
+++ b/src/equation_system/equations.jl
@@ -63,25 +63,25 @@ function generate_equations(c::AbstractCompositeModel, fns_own_global::F, ind_in
     # fns_branches_global,_ = get_own_functions(branches)
 
     nown = 1 # length(fns_own_global)
-    nlocal = length(fns_own_local)
     Nlocal = foo(fns_own_local)
 
     ilocal_childs = generate_ilocal_childs(iself, nown, fns_own_local)
-    offsets_parallel = generate_offsets_parallel(branches)
-    iparallel_childs = generate_iparallel_childs(iself, nlocal, nown, offsets_parallel, branches)
 
-    # ichildren = (ilocal_childs..., iparallel_childs...)
-    # add globals
-    # iself_ref[] += 1
-    # global_eqs   = CompositeEquation(iparent, iparallel_childs, iself_ref[], fns_own_global, leafs, Val(false))
+    # The equations contributed by each branch are not known yet: a branch's
+    # equation count depends on its own internal structure (e.g. a nested
+    # SeriesModel contributes more than one equation), not merely on the
+    # number of branches. The branch children are therefore left empty here
+    # and patched in below, once the branches' own equations have actually
+    # been generated (see attach_parallel_children).
     isGlobal = Val(B)
-    global_eqs0 = add_global_equations(iparent, ilocal_childs, iparallel_childs, iself_ref, fns_own_global, leafs, branches, ind_input, isGlobal, Val(1), local_el)
+    global_eqs0 = add_global_equations(iparent, ilocal_childs, iself_ref, fns_own_global, leafs, ind_input, isGlobal, Val(1), local_el)
     local_eqs = add_local_equations(global_eqs0.self, (), iself_ref, fns_own_local, fns_own_global, leafs, Nlocal, local_el)
     # need to correct the children of the global equations in absence of local equations (i.e. remove them)
-    global_eqs = correct_children(global_eqs0, local_eqs)
+    global_eqs1 = correct_children(global_eqs0, local_eqs)
 
     fn = counterpart(fns_own_global)
-    parallel_eqs = generate_equations_unroller(branches, fn, el_num, global_eqs, iself_ref)
+    parallel_eqs = generate_equations_unroller(branches, fn, el_num, global_eqs1, iself_ref)
+    global_eqs = attach_parallel_children(global_eqs1, parallel_eqs)
 
     # return  global_eqs, parallel_eqs
     return (global_eqs, local_eqs..., parallel_eqs...) |> superflatten
@@ -111,13 +111,6 @@ end
 
 generate_equations_unroller(::Tuple{}, ::F, el_num, global_eqs, iself_ref) where {F} = ()
 
-@generated function generate_iparallel_childs(iself, nlocal, nown, offsets_parallel, ::NTuple{N, Any}) where {N}
-    return quote
-        @inline
-        Base.@ntuple $N i -> iself + nlocal + offsets_parallel[i] + 1 + nown
-    end
-end
-
 @generated function generate_ilocal_childs(iself, nown, ::NTuple{N, Any}) where {N}
     return quote
         @inline
@@ -125,12 +118,28 @@ end
     end
 end
 
-@generated function generate_offsets_parallel(::NTuple{N, Any}) where {N}
+# A branch's own equations (`parallel_eqs[i]`) are generated after the parent
+# equation, so the parent's children referencing them cannot be computed
+# up-front from branch counts/offsets alone (a branch may contribute more
+# than one equation, e.g. a nested SeriesModel). Instead, once the branches'
+# equations exist, we patch the `.self` of each branch's top-level equation
+# into the parent's `child` tuple. A branch that contributed no equations
+# (e.g. not applicable to the current global function) is simply omitted.
+@inline first_self(::Tuple{}) = ()
+@inline first_self(eqs::Tuple) = (first(eqs).self,)
+
+@generated function collect_parallel_children(parallel_eqs::NTuple{N, Any}) where {N}
     return quote
         @inline
-        n = Base.@ntuple $N i -> i
-        (0, n...)
+        tops = Base.@ntuple $N i -> first_self(parallel_eqs[i])
+        superflatten(tops)
     end
+end
+
+function attach_parallel_children(eqs::CompositeEquation{IsGlobal, T, F, R, RT}, parallel_eqs) where {IsGlobal, T, F, R, RT}
+    (; parent, child, self, fn, rheology, ind_input, el_number) = eqs
+    children = (child..., collect_parallel_children(parallel_eqs)...)
+    return CompositeEquation(parent, children, self, fn, rheology, ind_input, Val(IsGlobal), el_number)
 end
 
 
@@ -210,50 +219,10 @@ global_eltype_numbering(c::AbstractViscosity, counter_v::Base.RefValue, counter_
 global_eltype_numbering(c::AbstractElasticity, counter_v::Base.RefValue, counter_el::Base.RefValue, counter_pl::Base.RefValue) = counter_el[] += 1
 global_eltype_numbering(c::AbstractPlasticity, counter_v::Base.RefValue, counter_el::Base.RefValue, counter_pl::Base.RefValue) = counter_pl[] += 1
 
-@inline has_children(::F, branch) where {F} = Val(true)
-@inline has_children(::typeof(compute_pressure), branch) = isvolumetric(branch)
-@inline has_children(::typeof(compute_volumetric_strain_rate), branch) = isvolumetric(branch)
-
-@inline correct_children(fn::F, branch::AbstractCompositeModel, children) where {F} = correct_children(children, has_children(fn, branch))
-@generated function correct_children(fn::F, branch::NTuple{N, AbstractCompositeModel}, children) where {F, N}
-    return quote
-        new_children = Base.@ntuple $N i -> correct_children(children[i], has_children(fn, branch[i]))
-        return superflatten(new_children)
-    end
-end
-@inline correct_children(children, ::Val{true}) = children
-@inline correct_children(::Any, ::Val{false}) = ()
-
-@generated function add_global_equations(iparent, ilocal_childs, iparallel_childs, iself_ref, fns_own_global::NTuple{F, Any}, leafs, branches, ::Val{N}, el_number) where {F, N}
-    return quote
-        Base.@ntuple $N i -> begin
-            @inline
-            iself_ref[] += 1
-            corrected_children = correct_children(fns_own_global[i], branches, iparallel_childs)
-            children = (ilocal_childs..., corrected_children...) .+ (i - 1)
-            CompositeEquation(iparent, children, iself_ref[], fns_own_global[i], leafs, Val(true), el_number)
-        end
-    end
-end
-
-@generated function add_global_equations(iparent, ilocal_childs, iparallel_childs, iself_ref, fns_own_global::F, leafs, branches, ::Val{N}, el_number) where {F, N}
-    return quote
-        Base.@ntuple $N i -> begin
-            @inline
-            iself_ref[] += 1
-            corrected_children = correct_children(fns_own_global[i], branches, iparallel_childs)
-            children = (ilocal_childs..., corrected_children...) .+ (i - 1)
-            CompositeEquation(iparent, children, iself_ref[], fns_own_global, leafs, Val(true), el_number)
-        end
-    end
-end
-
-function add_global_equations(iparent, ilocal_childs, iparallel_childs, iself_ref, fns_own_global::F, leafs, branches, ind_input, ::Val{B}, ::Val{1}, el_number) where {F, B}
+function add_global_equations(iparent, ilocal_childs, iself_ref, fns_own_global::F, leafs, ind_input, ::Val{B}, ::Val{1}, el_number) where {F, B}
     @inline
     iself_ref[] += 1
-    corrected_children = correct_children(fns_own_global, branches, iparallel_childs)
-    children = (ilocal_childs..., corrected_children...)
-    return CompositeEquation(iparent, children, iself_ref[], fns_own_global, leafs, ind_input, Val(B), el_number)
+    return CompositeEquation(iparent, ilocal_childs, iself_ref[], fns_own_global, leafs, ind_input, Val(B), el_number)
 end
 
 @generated function add_local_equations(iparent, ilocal_childs, iself_ref, fns_own_local::F1, fns_own_global::F2, leafs, ::Val{N}, el_number) where {N, F1, F2}

--- a/test/test_equation_graphs.jl
+++ b/test/test_equation_graphs.jl
@@ -81,9 +81,39 @@ end
             (; self = 3, parent = 1, child = (4,), fn = :compute_stress, ind_input = 0, el_number = (4,)),
             (; self = 4, parent = 3, child = (), fn = :compute_strain_rate, ind_input = 0, el_number = (5, 1)),
         ),
+        # first branch contributes 2 equations (nested SeriesModel), second branch contributes 1;
+        SeriesModel(ParallelModel(v1, SeriesModel(v1, v1)), ParallelModel(v1)) => (
+            (; self = 1, parent = 0, child = (2, 4), fn = :compute_strain_rate, ind_input = 1, el_number = ()),
+            (; self = 2, parent = 1, child = (3,), fn = :compute_stress, ind_input = 0, el_number = (1,)),
+            (; self = 3, parent = 2, child = (), fn = :compute_strain_rate, ind_input = 0, el_number = (2, 3)),
+            (; self = 4, parent = 1, child = (), fn = :compute_stress, ind_input = 0, el_number = (4,)),
+        ),
     )
 
     for (model, expected) in cases
         @test equation_graph(model) == expected
     end
+end
+
+@testset "branch-order equation wiring (multi-equation branch before another branch)" begin
+    # branch 1: v(1) ∥ [v(1) — v(1)]  -> contributes 2 equations
+    # branch 2: v(1) alone            -> contributes 1 equation
+    # the two branches are in series
+    c = SeriesModel(
+        ParallelModel(LinearViscosity(1.0), SeriesModel(LinearViscosity(1.0), LinearViscosity(1.0))),
+        ParallelModel(LinearViscosity(1.0)),
+    )
+
+    vars   = (; ε = 1.0)
+    others = (; dt = 1.0)
+
+    x0  = initial_guess_x(c, vars, (;), others)
+    sol = solve(c, x0, vars, others)
+
+    η_b1 = 1.0 + 1 / (1 / 1.0 + 1 / 1.0)
+    η_b2 = 1.0
+    η_tot = 1 / (1 / η_b1 + 1 / η_b2)
+    τ_analytic = 2 * η_tot * vars.ε
+
+    @test sol[1] ≈ τ_analytic
 end

--- a/test/test_jacobians.jl
+++ b/test/test_jacobians.jl
@@ -179,7 +179,7 @@ end
     x = initial_guess_x(c, vars, args, others)
     J = ForwardDiff.jacobian(y -> compute_residual(c, y, vars, others), x)
     J_sol = SA[
-        1.0e-20   1.0      1.0       0.0
+        1.0e-20   1.0      0.0       1.0
         -1.0      2.0e20   1.0       0.0
         0.0      -1.0      1.5e-20   0.0
         -1.0      0.0      0.0       3.0e20


### PR DESCRIPTION
Hey,

Now that the repo is public, I had some fun playing a bit with it. Looking forward to use it more. I think I found a bug while doing so that is a bit nasty.
The simple MWE is the following:

```
using RheologyCalculator, Test
include("rheologies/RheologyDefinitions.jl")

c1 = SeriesModel(
    ParallelModel(LinearViscosity(1.0)),
    ParallelModel(LinearViscosity(1.0), SeriesModel(LinearViscosity(1.0), LinearViscosity(1.0))),
)

# same but with complex ParallelModel first!
c2 = SeriesModel(
    ParallelModel(LinearViscosity(1.0), SeriesModel(LinearViscosity(1.0), LinearViscosity(1.0))),
    ParallelModel(LinearViscosity(1.0)),
)

vars   = (; ε = 1.0)
others = (; dt = 1.0)

x01  = initial_guess_x(c1, vars, (;), others)
x02  = initial_guess_x(c2, vars, (;), others)
sol1 = solve(c1, x01, vars, others)
sol2 = solve(c2, x02, vars, others)

η_b1 = 1.0 + 1 / (1 / 1.0 + 1 / 1.0)
η_b2 = 1.0
η_tot = 1 / (1 / η_b1 + 1 / η_b2)
τ_analytic = 2 * η_tot * vars.ε

@show sol1[1], sol2[2], τ_analytic
```

which gives (1.2000000000000002, 0.5, 1.2000000000000002).
So the case with the complex branch before the simpler one gives the wrong solution. This propagates to much more complex SeriesModel() with more branches as long as there are at least 2 elements in any of the branches before the last one. Maybe introduced by #18?

Looking at the code, `generate_offsets_parallel`/`generate_iparallel_childs` precomputes each branch's assumed equation index as base + (branch_index - 1), i.e., it assumes every branch contributes exactly one equation, laid out consecutively. So, if the previous branch has multiple equations, for instance ParallelModel(LinearViscosity(1.0), SeriesModel(LinearViscosity(1.0), LinearViscosity(1.0))), then only the last equation from that branch is taken and propagated. So the bug is not showing for most cases when you have only 2 branches and the complex one is the last one. Hopefully, I am clear 😅

So the current code calculates where each branch's equation should be from branch counts, which is wrong whenever a branch's actual equation count differs from 1. With this PR, we read where each branch's equation actually ended up, after generating it, so it's correct regardless of how many equations any branch contributes or in what order. Also simplifies a bit some of the code, by removing some functions. I am not too familiar with the code base, so I had some help from Claude to do that, so please check carefully. But the bug is fixed on this PR, and I did not observe any regression in performance after. I also added a test and fixed a previous one.

If you find a more elegant way, feel free to ignore this PR!

EDIT:

For posterity, the MWE reported here is not correct, here is a better one:

```
using RheologyCalculator
include("rheologies/RheologyDefinitions.jl")

v1 = LinearViscosity(1.0)
v2 = LinearViscosity(2.0)
s1 = SeriesModel(v1, v2) # η_s1 = 2/3
p = ParallelModel(s1, v2) # η_p = 2/3 + 2 = 8/3
c = SeriesModel(p, p) # η_c = 4/3

vars = (; ε = 1.0)
args = (; τ = 1.0)

x = initial_guess_x(c, vars, args, (;))
sol = solve(c, x, vars, (;))
@show sol[1]
```
This should report 2.6666666 but was giving 2.2857142857142856 before the fix. 
