### PR TITLE
Optims plastic case

### DIFF
--- a/src/equation_system/solver.jl
+++ b/src/equation_system/solver.jl
@@ -21,7 +21,6 @@ of the corrected effective strain-rate tensor.
 - `verbose`: print the final iteration count, residual norm, and line-search step.
 """
 function solve(c::AbstractCompositeModel, x::SVector, vars0, others; xnorm0=nothing, atol::Float64 = 1.0e-12, rtol::Float64 = 1.0e-12, itermax = 1.0e4, verbose::Bool = false)
-   
     # Pre-correct ONLY the direct elastic leafs of the outer composite
     # (simple Maxwell backstress).  Tensor arithmetic is used here so that
     # second_invariant(ε + τ0/(2G·dt)) is evaluated correctly even for
@@ -36,7 +35,6 @@ function solve(c::AbstractCompositeModel, x::SVector, vars0, others; xnorm0=noth
     # vars = merge((; ε = εII), vars0)
     xnorm = correct_xnorm(x, xnorm0)
     r     = compute_residual(c, x, vars, others)   # initial residual
-    
     it = 0
     er = Inf
     er0 = mynorm(r, xnorm)
@@ -47,7 +45,7 @@ function solve(c::AbstractCompositeModel, x::SVector, vars0, others; xnorm0=noth
 
         J = ForwardDiff.jacobian(y -> compute_residual(c, y, vars, others), x)
         Δx = backsolve(J, r)
-        if it > 1 
+        if it > 1
             α = bt_line_search(Δx, x, c, vars, others, xnorm; α = 1.0, ρ = 0.5, lstol = 0.95, α_min = 0.1)
         end
         x += α .* Δx
@@ -74,7 +72,9 @@ end
     bt_line_search(Δx, x, composite, vars, others, xnorm; α=1.0, ρ=0.5, lstol=0.9, α_min=1.0e-8)
 
 Backtracking line search that repeatedly shrinks `α` by `ρ` until the residual
-norm at `x + α * Δx` is at most `lstol` times the current residual norm.
+norm at `x + α * Δx` is at most `lstol` times the current residual norm. The
+undamped full step (`α = 1.0`) is accepted outright whenever it does not
+increase the residual, without requiring the stricter `lstol` reduction.
 """
 function bt_line_search(Δx, x, composite, vars, others, xnorm; α = 1.0, ρ = 0.5, lstol = 0.9, α_min = 1.0e-8)
 
@@ -92,7 +92,8 @@ function bt_line_search(Δx, x, composite, vars, others, xnorm; α = 1.0, ρ = 0
         perturbed_rnorm = mynorm(perturbed_r, xnorm)
 
         # Check whether residual is sufficiently reduced
-        if perturbed_rnorm ≤ lstol * rnorm
+        # for α = 1, only check if the residual decreases
+        if perturbed_rnorm ≤ (α == 1.0 ? 1.0 : lstol) * rnorm
             break
         end
 

--- a/test/test_solver_convergence.jl
+++ b/test/test_solver_convergence.jl
@@ -1,0 +1,78 @@
+using Test, StaticArrays
+import RheologyCalculator: mynorm, _direct_leaf_elastic_correction, second_invariant_value
+
+function converged_residual(c, x, vars0, others, xnorm)
+    ε_corr = _direct_leaf_elastic_correction(c, vars0.ε, others)
+    εII    = second_invariant_value(vars0.ε .+ ε_corr)
+    vars   = merge(vars0, (; ε = εII))
+    r = compute_residual(c, x, vars, others)
+    return mynorm(r, xnorm)
+end
+
+@testset "solver convergence regression" begin
+    @testset "yield-crossing hard step" begin
+        viscous     = LinearViscosity(1.0e22)
+        viscous_reg = LinearViscosity(1.0e20)
+        elastic     = IncompressibleElasticity(10.0e9)
+        plastic     = DruckerPrager(10.0e6, 30.0, 0.0)
+        c = SeriesModel(viscous, elastic, ParallelModel(viscous_reg, plastic))
+
+        vars   = vars_2D(1.0e-14)
+        args   = (; τ = 2.0e3, λ = 0.0)
+        others = (; dt = 1.0e8, τ0 = (zero_stress_tensor_2D(),), P = 1.0e6, P0 = (0.0,))
+        x      = initial_guess_x(c, vars, args, others)
+        xnorm  = normalisation_x(c, 1.0e6, second_invariant_2D(vars.ε))
+
+        # Step the constant-strain-rate loading path forward to just before
+        # the step at which the stress state crosses the yield surface.
+        τ_e, P_e = (zero_stress_tensor_2D(),), (0.0,)
+        x_hard, o_hard = x, others
+        for _ in 1:469
+            o = (; dt = others.dt, τ0 = τ_e, P = others.P, P0 = P_e)
+            x_hard, o_hard = x, o
+            x = solve(c, x, vars, o; xnorm0 = xnorm)
+            τ_e = elastic_stress_history_2D(c, x[1], vars.ε, τ_e, o)
+        end
+
+        x_conv = solve(c, x_hard, vars, o_hard; xnorm0 = xnorm, itermax = 10)
+        @test converged_residual(c, x_conv, vars, o_hard, xnorm) < 1.0e-8
+    end
+
+    @testset "cold-start overstress" begin
+        function run_case(overstress_fac, ϕ, C, εrate, dt)
+            viscous     = LinearViscosity(1.0e22)
+            viscous_reg = LinearViscosity(1.0e20)
+            elastic     = IncompressibleElasticity(30.0e9)
+            plastic     = DruckerPrager(C, ϕ, 0.0)
+            c = SeriesModel(viscous, elastic, ParallelModel(plastic, viscous_reg))
+
+            εᵢⱼ  = tensor_strain_rate_2D(εrate)
+            vars = (; ε = εᵢⱼ, θ = 0.0e0)
+
+            P            = 5.0e6
+            yield_stress = P * plastic.sinϕ + plastic.C * plastic.cosϕ
+            τ0ᵢⱼ         = (stress_tensor_from_invariant_2D(overstress_fac * yield_stress, εᵢⱼ),)
+
+            args   = (; τ = 0.0, λ = 0.0, P = P)
+            others = (; dt = dt, τ0 = τ0ᵢⱼ, P0 = (0.0,))
+
+            x     = initial_guess_x(c, vars, args, others)
+            xnorm = normalisation_x(c, 1.0e6, second_invariant_2D(vars.ε))
+
+            x_conv = solve(c, x, vars, others; xnorm0 = xnorm, itermax = 10)
+            return converged_residual(c, x_conv, vars, others, xnorm)
+        end
+
+        cases = (
+            ("baseline",             1.1,  5.0,  10.0e6, 1.0e-14, 1.0e8),
+            ("far above yield",      3.0,  5.0,  10.0e6, 1.0e-14, 1.0e8),
+            ("steep friction angle", 1.1,  45.0, 10.0e6, 1.0e-14, 1.0e8),
+            ("lower cohesion",       1.1,  5.0,  1.0e6,  1.0e-14, 1.0e8),
+            ("small timestep",       1.1,  5.0,  10.0e6, 1.0e-14, 1.0e6),
+        )
+
+        for (label, overstress_fac, ϕ, C, εrate, dt) in cases
+            @test run_case(overstress_fac, ϕ, C, εrate, dt) < 1.0e-8
+        end
+    end
+end


### PR DESCRIPTION
While playing a bit, I found some common cases where the current solver is struggling for the VEVP case for the first cold start solve.

Here are some examples I tested on a Drucker Prager, with comparison in the number of iterations with master and current branch with realistic parameters.
<details>
<summary> MWE</summary>

```julia
using RheologyCalculator, StaticArrays

include("../rheologies/RheologyDefinitions.jl")
include("tensor_helpers.jl")

function count_iterations(c, x, vars, others, xnorm)
    pipe = Pipe()
    Base.link_pipe!(pipe; reader_supports_async = true, writer_supports_async = true)
    redirect_stdout(pipe) do
        solve(c, x, vars, others; xnorm0 = xnorm, verbose = true)
    end
    close(Base.pipe_writer(pipe))
    m = match(r"Iterations:\s*(\d+)", read(pipe, String))
    return m === nothing ? 1 : parse(Int, m.captures[1])
end

# Cold-start solve (guess τ = 0, λ = 0) against a stress history τ0 already
# `overstress_fac` times the yield stress: the initial point sits above the
# yield surface, so the very first Newton step must return-map it back down.
function run_case(overstress_fac, ϕ, C, εrate, dt)
    viscous     = LinearViscosity(1.0e22)
    viscous_reg = LinearViscosity(1.0e20)
    elastic     = IncompressibleElasticity(30.0e9)
    plastic     = DruckerPrager(C, ϕ, 0.0)
    c = SeriesModel(viscous, elastic, ParallelModel(plastic, viscous_reg))

    εᵢⱼ  = tensor_strain_rate_2D(εrate)
    vars = (; ε = εᵢⱼ, θ = 0.0e0)

    P            = 5.0e6
    yield_stress = P * plastic.sinϕ + plastic.C * plastic.cosϕ
    τ0ᵢⱼ         = (stress_tensor_from_invariant_2D(overstress_fac * yield_stress, εᵢⱼ),)

    args   = (; τ = 0.0, λ = 0.0, P = P)
    others = (; dt = dt, τ0 = τ0ᵢⱼ, P0 = (0.0,))

    x     = initial_guess_x(c, vars, args, others)
    xnorm = normalisation_x(c, 1.0e6, second_invariant_2D(vars.ε))

    return count_iterations(c, x, vars, others, xnorm)
end

# Baseline: overstress_fac = 1.1, ϕ = 5.0, C = 10e6, εrate = 1e-14, dt = 1e8.
# Each case varies one parameter away from that baseline.
#
#                              iterations
#   case                    this branch   main
#   barely above yield           3         145
#   baseline                     3         138
#   moderately above yield       3         148
#   far above yield              3         147
#   extreme                      3         301
#   steeper friction angle       3         141
#   steep friction angle         3         145
#   lower cohesion               3         146
#   slower loading              138        203
#   faster loading                3           3
#   small timestep                3         138
#   large timestep                3           3
cases = (
    ("barely above yield",     1.01, 5.0,  10.0e6, 1.0e-14, 1.0e8),
    ("baseline",               1.1,  5.0,  10.0e6, 1.0e-14, 1.0e8),
    ("moderately above yield", 1.5,  5.0,  10.0e6, 1.0e-14, 1.0e8),
    ("far above yield",        3.0,  5.0,  10.0e6, 1.0e-14, 1.0e8),
    ("extreme",                10.0, 5.0,  10.0e6, 1.0e-14, 1.0e8),
    ("steeper friction angle", 1.1,  30.0, 10.0e6, 1.0e-14, 1.0e8),
    ("steep friction angle",   1.1,  45.0, 10.0e6, 1.0e-14, 1.0e8),
    ("lower cohesion",         1.1,  5.0,  1.0e6,  1.0e-14, 1.0e8),
    ("slower loading",         1.1,  5.0,  10.0e6, 1.0e-15, 1.0e8),
    ("faster loading",         1.1,  5.0,  10.0e6, 1.0e-13, 1.0e8),
    ("small timestep",         1.1,  5.0,  10.0e6, 1.0e-14, 1.0e6),
    ("large timestep",         1.1,  5.0,  10.0e6, 1.0e-14, 1.0e10),
)

for (label, overstress_fac, ϕ, C, εrate, dt) in cases
    it = run_case(overstress_fac, ϕ, C, εrate, dt)
    println("case=\"$label\" iters=$it")
end
```

</details>


| Iterations per case | Branch | Main |
|------|-------:|-----:|
| Barely above yield | 3 | 145 |
| Baseline | 3 | 138 |
| Moderately above yield | 3 | 148 |
| Far above yield | 3 | 147 |
| Extreme | 3 | 301 |
| Steeper friction angle | 3 | 141 |
| Steep friction angle | 3 | 145 |
| Lower cohesion | 3 | 146 |
| Slower loading | 138 | 203 |
| Small timestep | 3 | 138 |

The fix is just 1 line, in the linesearch function. The idea is to only check that the residual decreases when `α = 1.0`, contrary to checking that it is lower than `lstol * rnorm` for that specific case. As such, we keep `α = 1.0` in most of the cases that were hard to solve before.

The reason it performs better has to do with the discontinous derivative at the yield condition I believe. So the local slope of the Jacobian is not a reliable predictor of the true nonlinear residual. As such, changing `α` is actually making things worse here because we are actually quite close to the solution contrary to what the comparison of the residuals is telling us. 

I have checked that this does not introduce any regression in other cases and I have also added a test that fails on Main. 
